### PR TITLE
Add legacy wrapper entrypoint

### DIFF
--- a/bot_econ_full_plus_rank_alerts.py
+++ b/bot_econ_full_plus_rank_alerts.py
@@ -1,0 +1,12 @@
+"""Compatibilidad con despliegues legacy.
+
+Render ejecuta este módulo directo (`python bot_econ_full_plus_rank_alerts.py`),
+pero la lógica actual vive en :mod:`bot_econ.main`. Este wrapper delega en el
+nuevo entrypoint para evitar errores de "file not found".
+"""
+
+from bot_econ.main import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a compatibility entrypoint script so Render deployments that invoke `python bot_econ_full_plus_rank_alerts.py` still work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d57c97f3cc832086fae3373e484a70