### PR TITLE
Fix DolarAPI endpoint for updated API paths

### DIFF
--- a/bot_econ/data_sources/dolar.py
+++ b/bot_econ/data_sources/dolar.py
@@ -46,7 +46,7 @@ async def fetch_oficial_blue() -> list[Quote]:
     names = ("oficial", "blue", "mep", "ccb", "ccl")
     results: list[Quote] = []
     for name in names:
-        data = await http.fetch_json(f"{DOLARAPI_BASE}/cotizaciones/{name}")
+        data = await http.fetch_json(f"{DOLARAPI_BASE}/dolares/{name}")
         ts = data.get("fechaActualizacion")
         timestamp = datetime.fromisoformat(ts) if isinstance(ts, str) else None
         results.append(


### PR DESCRIPTION
## Summary
- update the DolarAPI client to call the new `/dolares/{name}` endpoints so that quote fetching no longer fails with 404 responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d587e343008320b6bd7a602152e20a