### PR TITLE
Fix dolarapi endpoints

### DIFF
--- a/bot_econ/data_sources/dolar.py
+++ b/bot_econ/data_sources/dolar.py
@@ -2,11 +2,21 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from aiohttp import ClientResponseError
+
 from .http import get_http_client
 from .models import Quote
 
 CRYPTOYA_DOLAR_URL = "https://criptoya.com/api/dolar"
 DOLARAPI_BASE = "https://dolarapi.com/v1"
+
+# Endpoints published by dolarapi.com for the main exchange rates we display in the bot.
+# The API renamed several resources (e.g. ``mep`` -> ``bolsa`` and ``ccl`` ->
+# ``contadoconliqui``).  Requesting the legacy slugs now returns ``404`` and the
+# old code kept retrying until failing loudly during the prewarm task.  Sticking
+# to the official slugs avoids the error altogether while preserving the
+# original categories shown in the Telegram summary.
+DOLARAPI_SLUGS = ("oficial", "blue", "bolsa", "contadoconliqui", "cripto")
 
 
 def _try_float(value: float | int | str | None) -> float | None:
@@ -43,15 +53,22 @@ async def fetch_dolar_quotes() -> list[Quote]:
 
 async def fetch_oficial_blue() -> list[Quote]:
     http = await get_http_client()
-    names = ("oficial", "blue", "mep", "ccb", "ccl")
     results: list[Quote] = []
-    for name in names:
-        data = await http.fetch_json(f"{DOLARAPI_BASE}/dolares/{name}")
+    for slug in DOLARAPI_SLUGS:
+        try:
+            data = await http.fetch_json(f"{DOLARAPI_BASE}/dolares/{slug}")
+        except ClientResponseError as exc:
+            if exc.status == 404:
+                # Skip gracefully if the provider removes a rate. We rely on the
+                # API's official slugs so this should only trigger when they
+                # deprecate one of them.
+                continue
+            raise
         ts = data.get("fechaActualizacion")
         timestamp = datetime.fromisoformat(ts) if isinstance(ts, str) else None
         results.append(
             Quote(
-                name=name,
+                name=str(data.get("nombre") or slug),
                 buy=_try_float(data.get("compra")),
                 sell=_try_float(data.get("venta")),
                 last_update=timestamp,


### PR DESCRIPTION
## Summary
- update the dolarapi slug list to use the current endpoint names
- keep fetching the public display name returned by the API for friendlier labels
- ignore missing rates gracefully instead of failing the scheduled prewarm task

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d58b0a1a6c8320b37bf4ed4f9f24fa