### PR TITLE
Ensure python-telegram-bot webhook extra is installed

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -42,7 +42,7 @@
 ## 6) Pruebas locales
 ```bash
 python -m venv .venv && source .venv/bin/activate  # (en Windows: .venv\Scripts\activate)
-pip install -r requirements.txt
+pip install -r requirements.txt  # incluye la extra "webhooks" de PTB
 export BOT_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 python bot_econ_full_plus_rank_alerts.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot==20.8
+python-telegram-bot[webhooks]==20.8
 aiohttp==3.9.*
 APScheduler==3.10.*
 httpx==0.26.*


### PR DESCRIPTION
## Summary
- update python-telegram-bot dependency to install the webhooks extra required by start_webhook
- document the extra in the deployment readme so local setup matches production

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63460718c8320b13f7726a8a4cf4d