### PR TITLE
Ensure health routes are registered after webhook startup

### DIFF
--- a/bot_econ_full_plus_rank_alerts.py
+++ b/bot_econ_full_plus_rank_alerts.py
@@ -2695,7 +2695,6 @@ async def main():
     load_state()
     application = build_application()
     _schedule_all_subs(application)
-    setup_health_routes(application)
 
     alerts_task = None
     keepalive_task = None
@@ -2714,6 +2713,7 @@ async def main():
                 webhook_url=WEBHOOK_URL,
                 drop_pending_updates=True,
             )
+            setup_health_routes(application)
             updater_started = True
 
             await application.start()


### PR DESCRIPTION
## Summary
- ensure the webhook health routes are registered only after the updater webhook starts so the app instance is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76f221c5483209846a5873d02a634