### PR TITLE
Add Upstash env var placeholders to Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,5 +8,11 @@ services:
     envVars:
       - key: TELEGRAM_TOKEN
         sync: false          # cargalo en Render → Environment
+      - key: UPSTASH_REDIS_REST_URL
+        sync: false          # cargalo en Render → Environment
+      - key: UPSTASH_REDIS_REST_TOKEN
+        sync: false          # cargalo en Render → Environment
+      - key: UPSTASH_STATE_KEY     # opcional: solo si queres customizarlo
+        sync: false
       - key: PYTHON_VERSION
         value: 3.11.9


### PR DESCRIPTION
## Summary
- add Upstash REST credentials to the Render blueprint with sync disabled
- document optional Upstash state key placeholder alongside existing env vars

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcca2a7fe48320b5ce1e5f4234c491