### PR TITLE
Support Upstash Redis URL persistence

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -10,6 +10,7 @@
 - `BOT_TOKEN` — el token del bot de Telegram (NO hardcodear).
 - (opcional) `STATE_PATH` — ruta del archivo JSON donde se persiste el estado (`alerts`, `subs` y `pf`). Por defecto el bot usa `./state.json`, pero en Render conviene apuntarlo a `/var/tmp/state.json` (o a un volumen persistente) para minimizar pérdidas por redeploy.
 - (opcional) `UPSTASH_REDIS_REST_URL` y `UPSTASH_REDIS_REST_TOKEN` — si se definen, el bot persistirá todo en Upstash usando su API HTTP.
+- (opcional) `UPSTASH_REDIS_URL` (o las variantes `REDIS_URL` / `redis-url` que provee Render) — activa la persistencia vía cliente Redis nativo de Upstash. Se usa automáticamente si no hay credenciales REST configuradas.
 - (opcional) `UPSTASH_STATE_KEY` — clave del registro JSON dentro de Upstash (default `bot-econ-state`).
 
 ## 3) Deploy rápido (desde un repo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httpx==0.26.*
 certifi
 tzdata
 matplotlib==3.8.*
+redis>=5.0.0,<6


### PR DESCRIPTION
## Summary
- add support for persisting bot state through an Upstash Redis URL when REST credentials are unavailable
- lazily create the Redis client with graceful fallbacks to the existing state file logic
- document the new environment variable and add the redis dependency

## Testing
- python -m compileall bot_econ_full_plus_rank_alerts.py

------
https://chatgpt.com/codex/tasks/task_e_68e4895ecbec8320a96d5be314092ff4